### PR TITLE
enable resize so component isn't cut off

### DIFF
--- a/src/components/Stopwatch/manifest.json
+++ b/src/components/Stopwatch/manifest.json
@@ -2,6 +2,7 @@
   "displayName": "Stopwatch",
   "defaultWidth": 132,
   "defaultHeight": 82,
+  "resizeY": false,
   "components": "./index.js",
   "icon": "./icon.png",
   "props": [

--- a/src/components/Stopwatch/manifest.json
+++ b/src/components/Stopwatch/manifest.json
@@ -1,8 +1,8 @@
 {
   "displayName": "Stopwatch",
-  "defaultWidth": 126,
-  "defaultHeight": 90,
-  "resizeX": false,
+  "defaultWidth": 132,
+  "defaultHeight": 82,
+  "resizeY": false,
   "components": "./index.js",
   "icon": "./icon.png",
   "props": [

--- a/src/components/Stopwatch/manifest.json
+++ b/src/components/Stopwatch/manifest.json
@@ -2,7 +2,7 @@
   "displayName": "Stopwatch",
   "defaultWidth": 132,
   "defaultHeight": 82,
-  "resizeY": false,
+  "resizeY": true,
   "components": "./index.js",
   "icon": "./icon.png",
   "props": [

--- a/src/components/Stopwatch/manifest.json
+++ b/src/components/Stopwatch/manifest.json
@@ -2,7 +2,6 @@
   "displayName": "Stopwatch",
   "defaultWidth": 132,
   "defaultHeight": 82,
-  "resizeY": false,
   "components": "./index.js",
   "icon": "./icon.png",
   "props": [


### PR DESCRIPTION
Problem: Initial binding box was too small. Also, parts of the component were cut off if the timer/icons were sized too large

Solution: changed initial height/width and enabled resizing in the manifest